### PR TITLE
Potential fix for code scanning alert no. 1: Empty except

### DIFF
--- a/src/agronomist/github.py
+++ b/src/agronomist/github.py
@@ -168,8 +168,12 @@ class GitHubClient:
             tag = self.latest_release_tag(repo)
             if tag:
                 return tag
-        except NetworkError:
-            pass
+        except NetworkError as exc:
+            logger.debug(
+                "GitHub: failed to fetch latest release for %s, falling back to tags: %s",
+                repo,
+                exc,
+            )
         try:
             return self.latest_tag(repo)
         except NetworkError:


### PR DESCRIPTION
Potential fix for [https://github.com/Ops-Talks/agronomist/security/code-scanning/1](https://github.com/Ops-Talks/agronomist/security/code-scanning/1)

Keep the fallback logic unchanged, but replace the empty `except NetworkError: pass` with explicit handling that records why release lookup was skipped. The best fix is to catch `NetworkError as exc` and log at debug/warning level, then continue to `latest_tag`.

Edit only `src/agronomist/github.py`, inside `latest_ref` around lines 171–172:
- Change `except NetworkError:` to `except NetworkError as exc:`
- Replace `pass` with a logger call, e.g. `logger.debug(...)`, including `repo` and `exc`.

No new imports or dependencies are needed because `logger` is already defined.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
